### PR TITLE
Fix update swagger-ui workflow

### DIFF
--- a/.github/workflows/update-swagger.yml
+++ b/.github/workflows/update-swagger.yml
@@ -31,6 +31,7 @@ jobs:
           mv dist/index.html .
           # Fix references in index.html
           sed -i "s|https://petstore.swagger.io/v2/swagger.json|$ROOT_YAML|g" index.html
+          sed -i "s|<title>Swagger UI</title>|<title>Charging Module API</title>|g" index.html
           sed -i "s|href=\"./|href=\"dist/|g" index.html
           sed -i "s|src=\"./|src=\"dist/|g" index.html
           # Update current release

--- a/.github/workflows/update-swagger.yml
+++ b/.github/workflows/update-swagger.yml
@@ -18,7 +18,7 @@ jobs:
         if: steps.swagger-ui.outputs.current_tag != steps.swagger-ui.outputs.release_tag
         env:
           RELEASE_TAG: ${{ steps.swagger-ui.outputs.release_tag }}
-          SWAGGER_YAML: "swagger.yaml"
+          ROOT_YAML: "draft.yaml"
         run: |
           # Delete the dist directory and index.html
           rm -fr dist index.html
@@ -30,7 +30,7 @@ jobs:
           # Move index.html to the root
           mv dist/index.html .
           # Fix references in index.html
-          sed -i "s|https://petstore.swagger.io/v2/swagger.json|$SWAGGER_YAML|g" index.html
+          sed -i "s|https://petstore.swagger.io/v2/swagger.json|$ROOT_YAML|g" index.html
           sed -i "s|href=\"./|href=\"dist/|g" index.html
           sed -i "s|src=\"./|src=\"dist/|g" index.html
           # Update current release


### PR DESCRIPTION
The [template project](https://github.com/peter-evans/swagger-github-pages) we built this one from included a GitHub workflow to automatically check we're using the latest version of [swagger-ui](https://github.com/swagger-api/swagger-ui). If not it automatically handles creating a pull request with the update.

But we have only just spotted that it is expecting the root OpenAPI spec file to be called `swagger.yaml` and we opted to move away from that in an earlier commit. It also pulls down a new version of `index.html` and overwrites the one present. This means our change to the page title will also be lost.

So, this change updates the workflow to fix these issues before the next update PR is generated.