### PR TITLE
Remove npx call in package.json start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "OpenAPI spec for the Charging Module API service",
   "homepage": "https://github.com/DEFRA/sroc-charging-module-api-docs",
   "scripts": {
-    "start": "npx swagger-cli bundle --type yaml --dereference spec/openapi.yml --outfile draft.yml"
+    "start": "swagger-cli bundle --type yaml --dereference spec/openapi.yml --outfile draft.yml"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Pointed out that there is no need to reference [npx](https://docs.npmjs.com/cli/v7/commands/npx) from within a `package.json` file. This change removes the reference (tested locally and the command still works fine).