### PR TITLE
Update validation lists for `loss` and `supportedSourceName`

### DIFF
--- a/draft.yml
+++ b/draft.yml
@@ -1482,7 +1482,7 @@ paths:
                     - All Year
                   example: Summer
                 loss:
-                  description: Loss on which charge calculation based
+                  description: Loss on which charge calculation based. Note that this list differs from the list for sroc.
                   type: string
                   enum:
                     - High
@@ -1864,7 +1864,7 @@ paths:
                         - All Year
                       example: Summer
                     loss:
-                      description: Loss on which charge calculation based
+                      description: Loss on which charge calculation based. Note that this list differs from the list for sroc.
                       type: string
                       enum:
                         - High
@@ -2163,13 +2163,12 @@ paths:
                       maxLength: 240
                       example: 'Borehole at Runhall, Norfolk.'
                     loss:
-                      description: Loss on which charge calculation based
+                      description: Loss on which charge calculation based. Note that this list differs from the list for presroc.
                       type: string
                       enum:
                         - High
                         - Medium
                         - Low
-                        - Very Low
                       example: Medium
                     region:
                       description: A single-digit region identifier for a transaction or customer
@@ -2228,18 +2227,18 @@ paths:
                         - Lodes Granta Groundwater
                         - Lower Yorkshire Derwent
                         - Medway - Allington
-                        - Nene – Northampton
-                        - Nene – Water Newton
+                        - Nene - Northampton
+                        - Nene - Water Newton
                         - Ouse - Offord
-                        - Ouse – Eaton Socon
-                        - Ouse – Hermitage
+                        - Ouse - Eaton Socon
+                        - Ouse - Hermitage
                         - Rhee Groundwater
                         - Severn
                         - Thames
                         - Thet and Little Ouse Surface Water
                         - Waveney Groundwater
                         - Waveney Surface Water
-                        - Welland – Tinwell Sluices
+                        - Welland - Tinwell Sluices
                         - Witham and Ancholme
                         - Wye
                       example: Thames
@@ -4078,7 +4077,7 @@ paths:
                     - All Year
                   example: Summer
                 loss:
-                  description: Loss on which charge calculation based
+                  description: Loss on which charge calculation based. Note that this list differs from the list for sroc.
                   type: string
                   enum:
                     - High
@@ -4403,7 +4402,7 @@ paths:
                         - All Year
                       example: Summer
                     loss:
-                      description: Loss on which charge calculation based
+                      description: Loss on which charge calculation based. Note that this list differs from the list for sroc.
                       type: string
                       enum:
                         - High
@@ -4537,13 +4536,12 @@ paths:
                       type: boolean
                       example: false
                     loss:
-                      description: Loss on which charge calculation based
+                      description: Loss on which charge calculation based. Note that this list differs from the list for presroc.
                       type: string
                       enum:
                         - High
                         - Medium
                         - Low
-                        - Very Low
                       example: Medium
                     regionalChargingArea:
                       description: Name of the region to be used when determining the regional factor to be applied for a compensation charge

--- a/spec/schema/fields.yml
+++ b/spec/schema/fields.yml
@@ -423,7 +423,7 @@ supportedSource:
 supportedSourceName:
   description: "Boolean indicator to show whether a supported source supplement is to be added to a charge"
   type: string
-  enum: ['Candover', 'Dee', 'Earl Soham - Deben', 'Glen Groundwater', 'Great East Anglian Groundwater', 'Great East Anglian Surface Water', 'Kielder', 'Lodes Granta Groundwater', 'Lower Yorkshire Derwent', 'Medway - Allington', 'Nene – Northampton', 'Nene – Water Newton', 'Ouse - Offord', 'Ouse – Eaton Socon', 'Ouse – Hermitage', 'Rhee Groundwater', 'Severn', 'Thames', 'Thet and Little Ouse Surface Water', 'Waveney Groundwater', 'Waveney Surface Water', 'Welland – Tinwell Sluices', 'Witham and Ancholme', 'Wye']
+  enum: ['Candover', 'Dee', 'Earl Soham - Deben', 'Glen Groundwater', 'Great East Anglian Groundwater', 'Great East Anglian Surface Water', 'Kielder', 'Lodes Granta Groundwater', 'Lower Yorkshire Derwent', 'Medway - Allington', 'Nene - Northampton', 'Nene - Water Newton', 'Ouse - Offord', 'Ouse - Eaton Socon', 'Ouse - Hermitage', 'Rhee Groundwater', 'Severn', 'Thames', 'Thet and Little Ouse Surface Water', 'Waveney Groundwater', 'Waveney Surface Water', 'Welland - Tinwell Sluices', 'Witham and Ancholme', 'Wye']
   example: 'Thames'
 supportedSourceValue:
   description: Value in pence of the supported source supplement, where applied

--- a/spec/schema/fields.yml
+++ b/spec/schema/fields.yml
@@ -285,10 +285,15 @@ lineDescription:
   type: string
   maxLength: 240
   example: 'Borehole at Runhall, Norfolk.'
-loss:
-  description: "Loss on which charge calculation based"
+lossPresroc:
+  description: "Loss on which charge calculation based. Note that this list differs from the list for sroc."
   type: string
   enum: [High, Medium, Low, 'Very Low']
+  example: 'Medium'
+lossSroc:
+  description: "Loss on which charge calculation based. Note that this list differs from the list for presroc."
+  type: string
+  enum: [High, Medium, Low]
   example: 'Medium'
 lossFactor:
   description: "The loss factor applied to the calculation"

--- a/spec/schema/schemas.yml
+++ b/spec/schema/schemas.yml
@@ -176,7 +176,7 @@ calculateChargePostV2:
     season:
       $ref: 'fields.yml#/season'
     loss:
-      $ref: 'fields.yml#/loss'
+      $ref: 'fields.yml#/lossPresroc'
     twoPartTariff:
       $ref: 'fields.yml#/supplementaryTwoPartTariff'
     compensationCharge:
@@ -232,7 +232,7 @@ calculateChargePresrocPost:
     season:
       $ref: 'fields.yml#/season'
     loss:
-      $ref: 'fields.yml#/loss'
+      $ref: 'fields.yml#/lossPresroc'
     twoPartTariff:
       $ref: 'fields.yml#/supplementaryTwoPartTariff'
     compensationCharge:
@@ -295,7 +295,7 @@ calculateChargeSrocPost:
     compensationCharge:
       $ref: 'fields.yml#/compensationCharge'
     loss:
-      $ref: 'fields.yml#/loss'
+      $ref: 'fields.yml#/lossSroc'
     regionalChargingArea:
       $ref: 'fields.yml#/regionalChargingArea'
     section127Agreement:
@@ -617,7 +617,7 @@ transactionPostV2:
     season:
       $ref: 'fields.yml#/season'
     loss:
-      $ref: 'fields.yml#/loss'
+      $ref: 'fields.yml#/lossPresroc'
     twoPartTariff:
       $ref: 'fields.yml#/supplementaryTwoPartTariff'
     compensationCharge:
@@ -700,7 +700,7 @@ transactionPresrocPost:
     season:
       $ref: 'fields.yml#/season'
     loss:
-      $ref: 'fields.yml#/loss'
+      $ref: 'fields.yml#/lossPresroc'
     twoPartTariff:
       $ref: 'fields.yml#/supplementaryTwoPartTariff'
     compensationCharge:
@@ -803,7 +803,7 @@ transactionSrocPost:
     lineDescription:
       $ref: 'fields.yml#/lineDescription'
     loss:
-      $ref: 'fields.yml#/loss'
+      $ref: 'fields.yml#/lossSroc'
     region:
       $ref: 'fields.yml#/regionCode'
     regionalChargingArea:


### PR DESCRIPTION
The `loss` field has a slightly different set of values for sroc and presroc (where sroc is missing the `Very Low` value). We therefore update the docs to reflect this.

We also fix an issue where some values for `supportedSourceName` have an en-dash instead of a hyphen. This is being corrected in the CM and the rules service so we update the docs to match.