### PR TITLE
Update docs with v3 rebilling route

### DIFF
--- a/draft.yaml
+++ b/draft.yaml
@@ -4927,6 +4927,135 @@ paths:
                 message: Invalid request params input
   '/v2/{regime}/bill-runs/{rebillBillRunId}/invoices/{rebillInvoiceId}/rebill':
     patch:
+      operationId: RebillBillRunInvoiceV2
+      description: 'Request to rebill an invoice. Returns ID of the invoice that will cancel out the original invoice, and the one to replace it.'
+      tags:
+        - bill-run
+      parameters:
+        - name: regime
+          in: path
+          required: true
+          description: Charging regime to use
+          schema:
+            description: 'Short reference for a regime, referred to as a ''slug''. This is also what we expect to see in the path as the regime identifier when making a request'
+            type: string
+            enum:
+              - cfd
+              - pas
+              - wml
+              - wrls
+            example: wrls
+        - name: rebillBillRunId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating a bill run. When rebilling this represents the bill run you want to assign the new rebill invoices to.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating a bill run.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
+        - name: rebillInvoiceId
+          in: path
+          required: true
+          description: Internal ID (GUID) allocated by the CM when creating an invoice. When rebilling this represents the invoice you wish to rebill.
+          schema:
+            description: Internal ID (GUID) allocated by the CM when creating an invoice.
+            type: string
+            format: uuid
+            example: fd2ab097-3097-42bd-849e-046aa250a0d0
+      responses:
+        '201':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  invoices:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          description: Internal ID (GUID) allocated by the CM when creating an invoice.
+                          type: string
+                          format: uuid
+                          example: fd2ab097-3097-42bd-849e-046aa250a0d0
+                        rebilledType:
+                          description: The type of invoice in relation to rebilling. `O` (Original) means the invoice is not a result of rebilling. `C` (Cancel) is an invoice generated as a result of rebilling to 'cancel' the original invoice. `R` (Rebill) is the invoice generated to 'rebill' the original invoice.
+                          type: string
+                          enum:
+                            - C
+                            - O
+                            - R
+                          example: R
+              example:
+                invoices:
+                  - id: f62faabc-d65e-4242-a106-9777c1d57db7
+                    rebilledType: C
+                  - id: db82bf38-638a-44d3-b1b3-1ae8524d9c38
+                    rebilledType: R
+        '403':
+          description: Failed - not authorised
+          content:
+            application/json:
+              schema:
+                example:
+                  statusCode: 403
+                  error: Forbidden
+                  message: Unauthorised for regime 'wrls'
+        '404':
+          description: Failed - unknown ID
+          content:
+            application/json:
+              examples:
+                Bill run unknown:
+                  value:
+                    statusCode: 404
+                    error: Not found
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is unknown.
+                Invoice unknown:
+                  value:
+                    statusCode: 404
+                    error: Not found
+                    message: Invoice aa630ae0-0e51-4166-9025-66576c513f7f is unknown.
+        '409':
+          description: Failed - the invoice has already been rebilled
+          content:
+            application/json:
+              examples:
+                Invoice already rebilled:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 has already been rebilled.
+                Invoice already on bill run:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is already on bill run aa630ae0-0e51-4166-9025-66576c513f7f.
+                Invoice on an unbilled bill run:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Bill run aa630ae0-0e51-4166-9025-66576c513f7f does not have a status of 'billed'.
+                Invoice is for a different region:
+                  value:
+                    statusCode: 409
+                    error: Conflict
+                    message: Invoice ba31bd7b-a13e-4820-b15d-6f70fb2c52490 is for region T but bill run aa630ae0-0e51-4166-9025-66576c513f7f is for region A.
+        '422':
+          description: Failed - issue with the requested data
+          content:
+            application/json:
+              examples:
+                Bill run not linked to regime:
+                  value:
+                    statusCode: 422
+                    error: Unprocessable Entity
+                    message: Bill run fd2ab097-3097-42bd-849e-046aa250a0d0 is not linked to regime wrls.
+  '/v3/{regime}/bill-runs/{rebillBillRunId}/invoices/{rebillInvoiceId}/rebill':
+    patch:
       operationId: RebillBillRunInvoice
       description: 'Request to rebill an invoice. Returns ID of the invoice that will cancel out the original invoice, and the one to replace it.'
       tags:

--- a/spec/openapi.yml
+++ b/spec/openapi.yml
@@ -237,6 +237,9 @@ paths:
   '/v2/{regime}/bill-runs/{rebillBillRunId}/invoices/{rebillInvoiceId}/rebill':
     $ref: 'paths/v2/bill_runs/invoices/invoice_rebill.yml'
 
+  '/v3/{regime}/bill-runs/{rebillBillRunId}/invoices/{rebillInvoiceId}/rebill':
+    $ref: 'paths/v3/bill_runs/invoices/invoice_rebill.yml'
+
   '/v2/{regime}/bill-runs/{billRunId}/licences/{licenceId}':
     $ref: 'paths/v2/bill_runs/licences/licence.yml'
 

--- a/spec/paths/v3/bill_runs/invoices/invoice_rebill.yml
+++ b/spec/paths/v3/bill_runs/invoices/invoice_rebill.yml
@@ -1,5 +1,5 @@
 patch:
-  operationId: RebillBillRunInvoiceV2
+  operationId: RebillBillRunInvoice
   description: "Request to rebill an invoice. Returns ID of the invoice that will cancel out the original invoice, and the one to replace it."
   tags:
     - bill-run


### PR DESCRIPTION
https://eaflood.atlassian.net/jira/software/projects/CMEA/boards/907?selectedIssue=CMEA-244

We update the docs with the v3 rebilling route. As is our usual pattern, we rename the v2 route to `RebillBillRunInvoiceV2` and the new v3 route becomes `RebillBillRunInvoice`.