### PR TITLE
Add missing rebilledTransactionId to docs

### DIFF
--- a/draft.yml
+++ b/draft.yml
@@ -3627,6 +3627,11 @@ paths:
                                 description: Boolean indicator to show whether the transaction relates to a compensation charge
                                 type: boolean
                                 example: false
+                              rebilledTransactionId:
+                                description: If a rebilled transaction this is the ID of the originating transaction.
+                                type: string
+                                format: uuid
+                                example: 99999999-9999-9999-9999-999999999999
                               calculation:
                                 description: Copy of the Rules service JSON response for audit/reference purposes
                                 type: object
@@ -3660,6 +3665,7 @@ paths:
                           periodStart: '2018-04-01T00:00:00.000Z'
                           periodEnd: '2019-03-31T00:00:00.000Z'
                           compensationCharge: false
+                          rebilledTransactionId: eacbef6b-938c-4cc5-9650-594dc25b4a7b
                           calculation:
                             __DecisionID__: ba31bd7b-a13e-4820-b15d-6f70fb2c52490
                             WRLSChargingResponse:

--- a/spec/paths/v2/bill_runs/invoices/invoice.yml
+++ b/spec/paths/v2/bill_runs/invoices/invoice.yml
@@ -44,6 +44,7 @@ get:
                   periodStart: '2018-04-01T00:00:00.000Z'
                   periodEnd: '2019-03-31T00:00:00.000Z'
                   compensationCharge: false
+                  rebilledTransactionId: eacbef6b-938c-4cc5-9650-594dc25b4a7b
                   calculation:
                     __DecisionID__: ba31bd7b-a13e-4820-b15d-6f70fb2c52490
                     WRLSChargingResponse:

--- a/spec/schema/fields.yml
+++ b/spec/schema/fields.yml
@@ -334,6 +334,11 @@ rebilledInvoiceId:
   type: string
   format: uuid
   example: '99999999-9999-9999-9999-999999999999'
+rebilledTransactionId:
+  description: "If a rebilled transaction this is the ID of the originating transaction."
+  type: string
+  format: uuid
+  example: '99999999-9999-9999-9999-999999999999'
 rebilledType:
   description: "The type of invoice in relation to rebilling. `O` (Original) means the invoice is not a result of rebilling. `C` (Cancel) is an invoice generated as a result of rebilling to 'cancel' the original invoice. `R` (Rebill) is the invoice generated to 'rebill' the original invoice."
   type: string
@@ -379,7 +384,7 @@ section127Agreement:
   type: boolean
   example: false
 section127Factor:
-  description: The factor applied to the charge (if any) for a Section 127 agreement 
+  description: The factor applied to the charge (if any) for a Section 127 agreement
   type: number
   example: 0.5
 section130Agreement:

--- a/spec/schema/schemas.yml
+++ b/spec/schema/schemas.yml
@@ -540,6 +540,8 @@ invoice:
                   $ref: 'fields.yml#/periodEnd'
                 compensationCharge:
                   $ref: 'fields.yml#/compensationCharge'
+                rebilledTransactionId:
+                  $ref: 'fields.yml#/rebilledTransactionId'
                 calculation:
                   description: "Copy of the Rules service JSON response for audit/reference purposes"
                   type: object


### PR DESCRIPTION
Back in [SROC Charging Module API PR #456](https://github.com/DEFRA/sroc-charging-module-api/pull/456) we added the ability to link a rebilled transaction to its originating transaction record.

As part of this, we also included the `rebilledTransactionId` in the `GET /invoices/{id}` response but omitted adding it to the docs. It's been missing all this time but we've only just spotted that.

This change fixes the issue in the docs.