### PR TITLE
Fix broken link to API spec yaml file

### DIFF
--- a/dist/swagger-initializer.js
+++ b/dist/swagger-initializer.js
@@ -3,7 +3,7 @@ window.onload = function() {
 
   // the following lines will be replaced by docker/configurator, when it runs in a docker-container
   window.ui = SwaggerUIBundle({
-    url: "https://petstore.swagger.io/v2/swagger.json",
+    url: "draft.yaml",
     dom_id: '#swagger-ui',
     deepLinking: true,
     presets: [


### PR DESCRIPTION
We recently merged a [github actions update](https://github.com/DEFRA/sroc-charging-module-api-docs/pull/15) raised because of a change in the project which serves as our base/template.

When we did that we didn't spot that it had moved the initialisation block where we set our project details out of `index.html` and into `dist/swagger-initializer.js`. Because of this when you go to our site now it displays the docs for a pet store!

This change updates our project by putting back our project details into the `dist/swagger-initializer.js` file.

Not sure how we protect ourselves from a break like this in the future but we'll need to mull it over in the meantime.

> Because of the nature of the project this will be what we _think_ the fix is. We need to push and then possibly tinker to get it right.